### PR TITLE
Make simulation feature transparent with automatic default camera

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,63 @@
 //! let sdk_version = sdk.version().expect("get_sdk_version failed");
 //! println!("SDK version: {:?}", sdk_version);
 //! ```
+//!
+//! # Simulation Feature
+//!
+//! The `simulation` feature enables development and testing without physical hardware. When enabled,
+//! [`Sdk::new()`] automatically provides a simulated camera environment that behaves like real hardware.
+//!
+//! ## Enabling Simulation
+//!
+//! Add the feature to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! qhyccd-rs = { version = "0.1.7", features = ["simulation"] }
+//! ```
+//!
+//! ## Transparent Usage
+//!
+//! With simulation enabled, your code works identically for both real and simulated cameras:
+//!
+//! ```no_run
+//! use qhyccd_rs::Sdk;
+//!
+//! // Same code works with or without the simulation feature
+//! let sdk = Sdk::new().expect("Failed to initialize SDK");
+//! let cameras = sdk.cameras();
+//! println!("Found {} camera(s)", cameras.count());
+//! ```
+//!
+//! ## Default Simulated Camera
+//!
+//! When compiled with the `simulation` feature, [`Sdk::new()`] automatically provides:
+//!
+//! - **Camera**: QHY178M-Simulated (`SIM-QHY178M`)
+//!   - 3072x2048 resolution, 16-bit depth
+//!   - Cooler support for temperature control
+//!   - Full control API (gain, offset, exposure, etc.)
+//!
+//! - **Filter Wheel**: 7-position CFW
+//!   - Accessible via [`Sdk::filter_wheels()`]
+//!   - Complete control API support
+//!
+//! ## Custom Simulated Cameras
+//!
+//! For advanced use cases, use [`Sdk::new_simulated()`] and [`Sdk::add_simulated_camera()`]:
+//!
+//! ```
+//! # #[cfg(feature = "simulation")]
+//! # {
+//! use qhyccd_rs::{Sdk, simulation::SimulatedCameraConfig};
+//!
+//! let mut sdk = Sdk::new_simulated();
+//! let config = SimulatedCameraConfig::default()
+//!     .with_id("CUSTOM-CAM")
+//!     .with_filter_wheel(5);
+//! sdk.add_simulated_camera(config);
+//! # }
+//! ```
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 
 use std::ffi::{c_char, CStr};
@@ -36,15 +93,19 @@ use simulation::SimulatedCameraState;
 use libqhyccd_sys::{
     BeginQHYCCDLive, CancelQHYCCDExposing, CancelQHYCCDExposingAndReadout, CloseQHYCCD,
     ExpQHYCCDSingleFrame, GetQHYCCDChipInfo, GetQHYCCDEffectiveArea, GetQHYCCDExposureRemaining,
-    GetQHYCCDFWVersion, GetQHYCCDId, GetQHYCCDLiveFrame, GetQHYCCDMemLength, GetQHYCCDModel,
+    GetQHYCCDFWVersion, GetQHYCCDLiveFrame, GetQHYCCDMemLength, GetQHYCCDModel,
     GetQHYCCDNumberOfReadModes, GetQHYCCDOverScanArea, GetQHYCCDParam, GetQHYCCDParamMinMaxStep,
     GetQHYCCDReadMode, GetQHYCCDReadModeName, GetQHYCCDReadModeResolution, GetQHYCCDSDKVersion,
-    GetQHYCCDSingleFrame, GetQHYCCDType, InitQHYCCD, InitQHYCCDResource, IsQHYCCDCFWPlugged,
-    IsQHYCCDControlAvailable, OpenQHYCCD, ReleaseQHYCCDResource, ScanQHYCCD, SetQHYCCDBinMode,
+    GetQHYCCDSingleFrame, GetQHYCCDType, InitQHYCCD, IsQHYCCDCFWPlugged,
+    IsQHYCCDControlAvailable, OpenQHYCCD, ReleaseQHYCCDResource, SetQHYCCDBinMode,
     SetQHYCCDBitsMode, SetQHYCCDDebayerOnOff, SetQHYCCDParam, SetQHYCCDReadMode,
     SetQHYCCDResolution, SetQHYCCDStreamMode, StopQHYCCDLive, QHYCCD_ERROR, QHYCCD_ERROR_F64,
     QHYCCD_SUCCESS,
 };
+
+// These imports are only used when NOT simulating (real hardware path in Sdk::new)
+#[cfg(all(not(test), not(feature = "simulation")))]
+use libqhyccd_sys::{GetQHYCCDId, InitQHYCCDResource, ScanQHYCCD};
 
 #[cfg(test)]
 use crate::mocks::mock_libqhyccd_sys::{
@@ -538,6 +599,7 @@ impl Sdk {
     /// let sdk = Sdk::new();
     /// assert!(sdk.is_ok());
     /// ```
+    #[cfg(not(feature = "simulation"))]
     pub fn new() -> Result<Self> {
         match unsafe { InitQHYCCDResource() } {
             QHYCCD_SUCCESS => {
@@ -621,6 +683,41 @@ impl Sdk {
                 Err(eyre!(error))
             }
         }
+    }
+
+    /// Creates a new SDK instance with automatic simulation when the feature is enabled
+    ///
+    /// When compiled with the `simulation` feature, this automatically returns a simulated
+    /// SDK with a default camera (QHY178M-Simulated) that includes a 7-position filter wheel
+    /// and cooler support. This allows the same code to work seamlessly in both real and
+    /// simulated environments.
+    ///
+    /// For custom simulated camera configurations, use `new_simulated()` and
+    /// `add_simulated_camera()` instead.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use qhyccd_rs::Sdk;
+    ///
+    /// // Same code works with or without simulation feature
+    /// let sdk = Sdk::new().expect("Failed to initialize SDK");
+    /// let cameras = sdk.cameras();
+    /// println!("Found {} camera(s)", cameras.count());
+    /// ```
+    #[cfg(feature = "simulation")]
+    pub fn new() -> Result<Self> {
+        let mut sdk = Self::new_simulated();
+
+        // Add default simulated camera with 7-position filter wheel and cooler
+        let config = simulation::SimulatedCameraConfig::default()
+            .with_id("SIM-QHY178M")
+            .with_model("QHY178M-Simulated")
+            .with_filter_wheel(7)
+            .with_cooler();
+
+        sdk.add_simulated_camera(config);
+
+        Ok(sdk)
     }
 
     /// Creates a new SDK instance for simulation without scanning for real hardware

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,10 @@ use libqhyccd_sys::{
     GetQHYCCDFWVersion, GetQHYCCDLiveFrame, GetQHYCCDMemLength, GetQHYCCDModel,
     GetQHYCCDNumberOfReadModes, GetQHYCCDOverScanArea, GetQHYCCDParam, GetQHYCCDParamMinMaxStep,
     GetQHYCCDReadMode, GetQHYCCDReadModeName, GetQHYCCDReadModeResolution, GetQHYCCDSDKVersion,
-    GetQHYCCDSingleFrame, GetQHYCCDType, InitQHYCCD, IsQHYCCDCFWPlugged,
-    IsQHYCCDControlAvailable, OpenQHYCCD, ReleaseQHYCCDResource, SetQHYCCDBinMode,
-    SetQHYCCDBitsMode, SetQHYCCDDebayerOnOff, SetQHYCCDParam, SetQHYCCDReadMode,
-    SetQHYCCDResolution, SetQHYCCDStreamMode, StopQHYCCDLive, QHYCCD_ERROR, QHYCCD_ERROR_F64,
-    QHYCCD_SUCCESS,
+    GetQHYCCDSingleFrame, GetQHYCCDType, InitQHYCCD, IsQHYCCDCFWPlugged, IsQHYCCDControlAvailable,
+    OpenQHYCCD, ReleaseQHYCCDResource, SetQHYCCDBinMode, SetQHYCCDBitsMode, SetQHYCCDDebayerOnOff,
+    SetQHYCCDParam, SetQHYCCDReadMode, SetQHYCCDResolution, SetQHYCCDStreamMode, StopQHYCCDLive,
+    QHYCCD_ERROR, QHYCCD_ERROR_F64, QHYCCD_SUCCESS,
 };
 
 // These imports are only used when NOT simulating (real hardware path in Sdk::new)

--- a/src/tests/sdk_tests.rs
+++ b/src/tests/sdk_tests.rs
@@ -7,6 +7,7 @@ use crate::*;
 
 use crate::QHYError::{GetCameraIdError, InitSDKError, ScanQHYCCDError};
 
+#[cfg(not(feature = "simulation"))]
 fn new_sdk() -> Sdk {
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -58,6 +59,7 @@ fn new_sdk() -> Sdk {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_success() {
     //given
     //when
@@ -73,6 +75,7 @@ fn new_success() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn version_success() {
     //given
     let ctx_version = GetQHYCCDSDKVersion_context();
@@ -108,6 +111,7 @@ fn version_success() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn version_fail() {
     //given
     let ctx_version = GetQHYCCDSDKVersion_context();
@@ -135,6 +139,7 @@ fn version_fail() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn filter_wheels_success() {
     //given
     //filter wheels context is set up in new_sdk()
@@ -151,6 +156,7 @@ fn filter_wheels_success() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_init_fail() {
     //given
     let ctx_init = InitQHYCCDResource_context();
@@ -171,6 +177,7 @@ fn new_init_fail() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_scan_fail() {
     //given
     let ctx_init = InitQHYCCDResource_context();
@@ -187,6 +194,7 @@ fn new_scan_fail() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_get_id_fail() {
     //given
     let ctx_init = InitQHYCCDResource_context();
@@ -211,6 +219,7 @@ fn new_get_id_fail() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_get_id_invalid_utf8_fail() {
     //given
     let ctx_init = InitQHYCCDResource_context();
@@ -239,6 +248,7 @@ fn new_get_id_invalid_utf8_fail() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_with_broken_filter_wheel() {
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -302,6 +312,7 @@ fn new_with_broken_filter_wheel() {
 }
 
 #[test]
+#[cfg(not(feature = "simulation"))]
 fn new_fail_close() {
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);

--- a/tests/simulation/camera_tests.rs
+++ b/tests/simulation/camera_tests.rs
@@ -249,6 +249,43 @@ fn test_simulated_sdk_add_camera() {
 }
 
 #[test]
+fn test_sdk_new_with_default_simulated_camera() {
+    // Test that Sdk::new() automatically creates a simulated SDK with a default camera
+    let sdk = Sdk::new().expect("Failed to create SDK");
+
+    // Should have exactly 1 camera
+    assert_eq!(sdk.cameras().count(), 1);
+
+    let camera = sdk.cameras().next().unwrap();
+    assert_eq!(camera.id(), "SIM-QHY178M");
+    assert!(camera.is_simulated());
+
+    // Should have exactly 1 filter wheel (7 positions)
+    assert_eq!(sdk.filter_wheels().count(), 1);
+
+    let filter_wheel = sdk.filter_wheels().next().unwrap();
+
+    // Open the camera to verify it has cooler support
+    camera.open().expect("Failed to open camera");
+
+    // Verify camera has cooler support
+    assert!(
+        camera.is_control_available(Control::Cooler).is_some(),
+        "Camera should have cooler support"
+    );
+
+    camera.close().expect("Failed to close camera");
+
+    // Open and verify filter wheel has 7 positions
+    filter_wheel.open().expect("Failed to open filter wheel");
+    let num_filters = filter_wheel
+        .get_number_of_filters()
+        .expect("Failed to get number of filters");
+    assert_eq!(num_filters, 7, "Filter wheel should have 7 positions");
+    filter_wheel.close().expect("Failed to close filter wheel");
+}
+
+#[test]
 fn test_simulated_sdk_add_camera_with_filter_wheel() {
     let mut sdk = Sdk::new_simulated();
 


### PR DESCRIPTION
When the simulation feature is enabled, Sdk::new() now automatically returns a simulated SDK with a default QHY178M camera including a 7-position filter wheel and cooler support. This eliminates the need for users to write conditional code or manually create simulated cameras.