### PR TITLE
Fix simulation exposure cancellation and double-binning bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed simulation exposure cancellation bug: `stop_exposure()` now correctly preserves image data while `abort_exposure_and_readout()` discards it, matching QHYCCD SDK behavior
+- Fixed double-binning bug in simulation where ROI dimensions were incorrectly divided by binning factor, causing images to be half the expected size
+- Updated `get_current_image_dimensions()` to return ROI dimensions directly as they are already in binned coordinates when set via ASCOM Alpaca
+
+### Changed
+
+- Split simulation exposure cancellation into two distinct methods: `stop_exposure()` (preserves image) and `abort_exposure()` (discards image)
+- Updated design documentation to reflect exposure cancellation behavior and ROI/binning coordinate system
+
 ## [0.1.8] - 2026-01-18
 
 ### Added

--- a/src/camera/imaging.rs
+++ b/src/camera/imaging.rs
@@ -448,7 +448,7 @@ impl Camera {
                 if !state.is_open {
                     return Err(eyre!(CameraNotOpenError));
                 }
-                state.cancel_exposure();
+                state.stop_exposure();
                 Ok(())
             }
         }
@@ -489,7 +489,7 @@ impl Camera {
                 if !state.is_open {
                     return Err(eyre!(CameraNotOpenError));
                 }
-                state.cancel_exposure();
+                state.abort_exposure();
                 Ok(())
             }
         }


### PR DESCRIPTION
Fixed two critical bugs in the simulation feature:

1. Exposure cancellation: Split cancel_exposure() into two methods:
   - stop_exposure(): Stops exposure but preserves image data
   - abort_exposure(): Stops exposure and discards image data This matches the QHYCCD SDK behavior (CancelQHYCCDExposing vs CancelQHYCCDExposingAndReadout)

2. Double-binning: Fixed get_current_image_dimensions() which was incorrectly applying binning division to ROI dimensions that are already in binned coordinates when set via ASCOM Alpaca. This was causing images to be half the expected size (768x512 instead of 1536x1024 with 2x2 binning)

Updated design documentation to reflect:
- New exposure cancellation methods and their behavior
- ROI/binning coordinate system in ASCOM Alpaca integration
- Pre-generation of images during start_exposure()
- Added missing rayon dependency documentation

All simulation tests pass and conformU camera compliance tests now pass.