### PR TITLE
Prepare v0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-01-19
+
 ### Fixed
 
 - Fixed simulation exposure cancellation bug: `stop_exposure()` now correctly preserves image data while `abort_exposure_and_readout()` discards it, matching QHYCCD SDK behavior

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qhyccd-rs"
-version = "0.1.8"
+version = "0.1.9"
 edition ="2021"
 rust-version = "1.68.0" # for proc-macro2 v1.0.104
 authors = ["Igor von Nyssen<igor@vonnyssen.com>"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current bindings are not complete, but will grow as functionality is needed for 
 
 ```toml
 [dependencies]
-qhyccd-rs = "0.1.8"
+qhyccd-rs = "0.1.9"
 ```
 
 ## Rust version requirements

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qhyccd-rs = { version = "0.1.8", features = ["simulation"] }
+qhyccd-rs = { version = "0.1.9", features = ["simulation"] }
 ```
 
 Or use it for development dependencies:
 
 ```toml
 [dev-dependencies]
-qhyccd-rs = { version = "0.1.8", features = ["simulation"] }
+qhyccd-rs = { version = "0.1.9", features = ["simulation"] }
 ```
 
 ### Transparent Usage

--- a/docs/qhyccd-rs.md
+++ b/docs/qhyccd-rs.md
@@ -1421,4 +1421,4 @@ The public API remains 100% backward compatible. All public types are re-exporte
 
 *Document Version: 1.1*
 *Last Updated: 2026-01-19*
-*qhyccd-rs Version: 0.1.8+*
+*qhyccd-rs Version: 0.1.9*


### PR DESCRIPTION
## Release Preparation for v0.1.9

This PR prepares the v0.1.9 release by updating version numbers and changelog.

### Changes
- ✅ Updated `Cargo.toml` version to 0.1.9
- ✅ Updated `CHANGELOG.md`: moved [Unreleased] changes to [0.1.9] section
- ✅ Updated `README.md` version references to 0.1.9
- ✅ Updated `docs/qhyccd-rs.md` version footer to 0.1.9

### Release Content (from CHANGELOG)

**Fixed:**
- Fixed simulation exposure cancellation bug: `stop_exposure()` now correctly preserves image data while `abort_exposure_and_readout()` discards it, matching QHYCCD SDK behavior
- Fixed double-binning bug in simulation where ROI dimensions were incorrectly divided by binning factor, causing images to be half the expected size
- Updated `get_current_image_dimensions()` to return ROI dimensions directly as they are already in binned coordinates when set via ASCOM Alpaca

**Changed:**
- Split simulation exposure cancellation into two distinct methods: `stop_exposure()` (preserves image) and `abort_exposure()` (discards image)
- Updated design documentation to reflect exposure cancellation behavior and ROI/binning coordinate system

### Next Steps
After merging:
1. Create git tag: `git tag v0.1.9 && git push origin v0.1.9`
2. Publish to crates.io: `cargo publish`
3. Create GitHub release with changelog content